### PR TITLE
Making cancel & submit button text to also be tooltip text

### DIFF
--- a/src/libs/imng-kendo-data-entry/src/lib/data-entry-dialog.component.html
+++ b/src/libs/imng-kendo-data-entry/src/lib/data-entry-dialog.component.html
@@ -23,6 +23,7 @@
 <ng-template #defaultDialogActionsTpl>
   <button
     name="imngDataEntryCancelBtn"
+    [title]="cancelButtonText"
     kendoButton
     (click)="cancel()"
     class="btn btn-secondary btn-sm">
@@ -30,6 +31,7 @@
   </button>
   <button
     name="imngDataEntrySubmitBtn"
+    [title]="submitButtonText"
     [attr.form]="formId"
     type="submit"
     kendoButton

--- a/src/libs/imng-kendo-data-entry/src/lib/data-entry-dialog.component.ts
+++ b/src/libs/imng-kendo-data-entry/src/lib/data-entry-dialog.component.ts
@@ -39,6 +39,7 @@ import { KENDO_BUTTON } from '@progress/kendo-angular-buttons';
       <button
         id="imngCancelDataEntry"
         name="imngCancelDataEntry"
+        [title]="cancelButtonText"
         kendoButton
         (click)="cancel()"
         class="btn btn-secondary btn-sm">
@@ -47,6 +48,7 @@ import { KENDO_BUTTON } from '@progress/kendo-angular-buttons';
       <button
         id="imngSubmitDataEntry"
         name="imngSubmitDataEntry"
+        [title]="submitButtonText"
         [attr.form]="formId"
         type="submit"
         kendoButton


### PR DESCRIPTION
Adding tooltip text by default would be beneficial so that you don't need to create new buttons to simply add a tooltip message.